### PR TITLE
fix: use archive.apache.org for Apache Ant download

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -17,7 +17,7 @@ const closureLinterUrl = 'https://github.com/google/closure-linter';
 const pythonGflagsUrl = 'https://github.com/google/python-gflags.git';
 const antName = 'apache-ant-1.10.15';
 const antTar = `${antName}.tar.gz`;
-const antUrl = `https://downloads.apache.org/ant/binaries/${antName}-bin.tar.gz`;
+const antUrl = `https://archive.apache.org/dist/ant/binaries/${antName}-bin.tar.gz`;
 
 const isDebug = process.env.DEBUG && process.env.DEBUG !== '0';
 


### PR DESCRIPTION
## Summary

- `downloads.apache.org` only hosts the **current** Ant release — the URL for `1.10.15` broke when a newer version was published
- Switched to `archive.apache.org` which permanently hosts all past releases, so this won't break again on future Ant releases
- This fixes the failing `build_and_generate` workflow (run [#27811305029](https://github.com/respond-io/awesome-phonenumber/actions/runs/27811305029))