### PR TITLE
fix: bump create-pull-request to v7 for signed commit support

### DIFF
--- a/.github/workflows/build_and_generate.yml
+++ b/.github/workflows/build_and_generate.yml
@@ -44,7 +44,7 @@ jobs:
         run: yarn build
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'feat: update libphonenumber to ${{ inputs.version_number }} and rebuild dist files'


### PR DESCRIPTION
## Summary

- `peter-evans/create-pull-request@v5` creates unsigned commits which the repo's signed-commit policy rejects with `GH013`
- Bumped to `v7` which uses the GitHub GraphQL API internally to create verified commits
- This fixes the failing `Create Pull Request` step in the `build_and_generate` workflow (run [#27811693754](https://github.com/respond-io/awesome-phonenumber/actions/runs/27811693754))