### PR TITLE
fix: add sign-commits: true to create-pull-request step

### DIFF
--- a/.github/workflows/build_and_generate.yml
+++ b/.github/workflows/build_and_generate.yml
@@ -58,6 +58,7 @@ jobs:
           branch: feature/update-libphonenumber-${{ inputs.version_number }}
           delete-branch: true
           base: master
+          sign-commits: true
       - name: Set PR URL output & Slack notification
         id: set-pr-url
         uses: ./.github/workflows/composite/slack_notification


### PR DESCRIPTION
## Summary

- `peter-evans/create-pull-request@v7` does **not** automatically use signed commits — `sign-commits: true` must be set explicitly
- Without it, the action still falls back to unsigned `git push` which fails the repo's `GH013` signed-commit policy
- Adds `sign-commits: true` to the `Create Pull Request` step